### PR TITLE
Unitframe - Add Icon Indicators options for size & opacity

### DIFF
--- a/FreeUI/core/configs.lua
+++ b/FreeUI/core/configs.lua
@@ -619,6 +619,8 @@ C.CharacterSettings = {
 			['gcd_spark'] = true,
 
 			['target_icon_indicator'] = true,
+			['target_icon_indicator_alpha'] = 0.5,
+			['target_icon_indicator_size'] = 16,
 
 			['power_bar'] = true,
 			['power_bar_height'] = 1,

--- a/FreeUI/gui/options.lua
+++ b/FreeUI/gui/options.lua
@@ -300,7 +300,10 @@ GUI.OptionsList = {
 		{},
 		{1, 'unitframe', 'enable_boss', L.GUI.UNITFRAME.ENABLE_BOSS},
 		{4, 'unitframe', 'boss_color_style', L.GUI.UNITFRAME.COLOR_STYLE, nil, {L.GUI.UNITFRAME.COLOR_STYLE_DEFAULT, L.GUI.UNITFRAME.COLOR_STYLE_CLASS, L.GUI.UNITFRAME.COLOR_STYLE_GRADIENT}},
-		{1, 'unitframe', 'enable_arena', L.GUI.UNITFRAME.ENABLE_ARENA}
+		{1, 'unitframe', 'enable_arena', L.GUI.UNITFRAME.ENABLE_ARENA},
+		{},
+		{3, 'unitframe', 'target_icon_indicator_alpha', L.GUI.UNITFRAME.TARGET_ICON_INDICATOR_ALPHA, nil, {.5, 1, .1}},
+		{3, 'unitframe', 'target_icon_indicator_size', L.GUI.UNITFRAME.TARGET_ICON_INDICATOR_SIZE, true, {16, 32, 8}}
 	},
 	[13] = {
 		-- groupframes

--- a/FreeUI/locales/enUS.lua
+++ b/FreeUI/locales/enUS.lua
@@ -645,7 +645,9 @@ L.GUI = {
 		['COLOR_STYLE'] = 'Health color',
 		['COLOR_STYLE_DEFAULT'] = 'Default white',
 		['COLOR_STYLE_CLASS'] = 'Class colored',
-		['COLOR_STYLE_GRADIENT'] = 'Percentage gradient'
+		['COLOR_STYLE_GRADIENT'] = 'Percentage gradient',
+		['TARGET_ICON_INDICATOR_ALPHA'] = 'Icon Indicator opacity',
+		['TARGET_ICON_INDICATOR_SIZE'] = 'Icon Indicator size'
 	},
 	['GROUPFRAME'] = {
 		['NAME'] = 'Groupframe',

--- a/FreeUI/modules/unitframe/elements.lua
+++ b/FreeUI/modules/unitframe/elements.lua
@@ -1639,8 +1639,8 @@ function UNITFRAME:AddRaidTargetIndicator(self)
 
 	local raidTargetIndicator = self.Health:CreateTexture(nil, 'OVERLAY')
 	raidTargetIndicator:SetTexture(C.Assets.target_icon)
-	raidTargetIndicator:SetAlpha(.5)
-	raidTargetIndicator:SetSize(16, 16)
+	raidTargetIndicator:SetAlpha(C.DB.unitframe.target_icon_indicator_alpha)
+	raidTargetIndicator:SetSize(C.DB.unitframe.target_icon_indicator_size, C.DB.unitframe.target_icon_indicator_size)
 	raidTargetIndicator:SetPoint('CENTER', self)
 
 	self.RaidTargetIndicator = raidTargetIndicator


### PR DESCRIPTION
Hey!

This is a small PR to add the option to increase icon indicator's opacity and size as I was unable to clearly see them during my last raid.

A preview with max settings (opacity = 1, size = 32)
![image](https://user-images.githubusercontent.com/586848/99961944-9a771200-2d8f-11eb-8b8d-06da61f9319b.png)
